### PR TITLE
fix: docker command from README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ The most KISS single user URL shortener there is.
 docker run -e JSI_BaseUrl=<your-url> \
            -e JSI_Account__Username=<your-username> \
            -e JSI_Account__Password=<your-password> \
-           -p 80:8080
+           -p 80:8080 \
            miawinter/just-short-it:latest
 ```
 


### PR DESCRIPTION
My system :- Docker version 26.0.0,  Docker Compose version v2.25.0
Current command shows this 
```bash
"docker run" requires at least 1 argument.
See 'docker run --help'.

Usage:  docker run [OPTIONS] IMAGE [COMMAND] [ARG...]

Create and run a new container from an image
-bash: miawinter/just-short-it:latest: No such file or directory
```